### PR TITLE
Fix tests

### DIFF
--- a/vault/resource_aws_secret_backend_role_test.go
+++ b/vault/resource_aws_secret_backend_role_test.go
@@ -27,10 +27,10 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
@@ -38,10 +38,10 @@ func TestAccAWSSecretBackendRole_basic(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
 				),
@@ -62,10 +62,10 @@ func TestAccAWSSecretBackendRole_import(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
@@ -96,10 +96,10 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_basic(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_basic),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_basic),
 				),
@@ -107,10 +107,10 @@ func TestAccAWSSecretBackendRole_nested(t *testing.T) {
 			{
 				Config: testAccAWSSecretBackendRoleConfig_updated(name, backend, accessKey, secretKey),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "name", fmt.Sprintf("%s-policy-inline", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_inline", "backend", backend),
 					testCheckResourceAttrJSON("vault_aws_secret_backend_role.test_policy_inline", "policy", testAccAWSSecretBackendRolePolicyInline_updated),
-					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", name),
+					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "name", fmt.Sprintf("%s-policy-arn", name)),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "backend", backend),
 					resource.TestCheckResourceAttr("vault_aws_secret_backend_role.test_policy_arn", "policy_arn", testAccAWSSecretBackendRolePolicyArn_updated),
 				),
@@ -145,7 +145,7 @@ resource "vault_aws_secret_backend" "test" {
   secret_key = "%s"
 }
 
-resource "vault_aws_secret_backend_role" "test_inline_policy" {
+resource "vault_aws_secret_backend_role" "test_policy_inline" {
   name = "%s-policy-inline"
   policy = %q
   backend = "${vault_aws_secret_backend.test.path}"


### PR DESCRIPTION
Hi, this is an addition to your pull request https://github.com/terraform-providers/terraform-provider-vault/pull/79, which should fix the acceptance tests.

I cloned your branch locally and tried to run tests and found they are all failing because things were not aligned in them (appears that no one has actually ever ran them).


Before fixing tests:

```sh
$make testacc TESTARGS='-run=TestAccAWSSecretBackendRole_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSecretBackendRole_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
=== RUN   TestAccAWSSecretBackendRole_basic
--- FAIL: TestAccAWSSecretBackendRole_basic (0.50s)
    testing.go:434: Step 0 error: Check failed: Check 1/6 error: Not found: vault_aws_secret_backend_role.test_policy_inline
FAIL
FAIL    github.com/terraform-providers/terraform-provider-vault/vault   0.522s
make: *** [testacc] Error 1

$ make testacc TESTARGS='-run=TestAccAWSSecretBackendRole_import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSecretBackendRole_import -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
=== RUN   TestAccAWSSecretBackendRole_import
--- FAIL: TestAccAWSSecretBackendRole_import (0.49s)
    testing.go:434: Step 0 error: Check failed: Check 1/6 error: Not found: vault_aws_secret_backend_role.test_policy_inline
FAIL
FAIL    github.com/terraform-providers/terraform-provider-vault/vault   0.510s
make: *** [testacc] Error 1

$ make testacc TESTARGS='-run=TestAccAWSSecretBackendRole_nested'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSecretBackendRole_nested -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
=== RUN   TestAccAWSSecretBackendRole_nested
--- FAIL: TestAccAWSSecretBackendRole_nested (0.50s)
    testing.go:434: Step 0 error: Check failed: Check 1/6 error: Not found: vault_aws_secret_backend_role.test_policy_inline
FAIL
FAIL    github.com/terraform-providers/terraform-provider-vault/vault   0.523s
make: *** [testacc] Error 1
```

After fixing tests:

```sh
$ make testacc TESTARGS='-run=TestAccAWSSecretBackendRole_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSecretBackendRole_basic -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
=== RUN   TestAccAWSSecretBackendRole_basic
--- PASS: TestAccAWSSecretBackendRole_basic (1.64s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   1.663s

$ make testacc TESTARGS='-run=TestAccAWSSecretBackendRole_import'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSecretBackendRole_import -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
=== RUN   TestAccAWSSecretBackendRole_import
--- PASS: TestAccAWSSecretBackendRole_import (1.06s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   1.088s

$ make testacc TESTARGS='-run=TestAccAWSSecretBackendRole_nested'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test $(go list ./... |grep -v 'vendor') -v -run=TestAccAWSSecretBackendRole_nested -timeout 120m
?       github.com/terraform-providers/terraform-provider-vault [no test files]
=== RUN   TestAccAWSSecretBackendRole_nested
--- PASS: TestAccAWSSecretBackendRole_nested (1.60s)
PASS
ok      github.com/terraform-providers/terraform-provider-vault/vault   1.624s
```